### PR TITLE
Update accent colour

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -43,7 +43,7 @@
 	--background-colour : var(--background-light-theme);
 	--header-color: var(--header-light-theme);
 	
-	--accent: var(--yellow);
+	--accent: var(--green);
 	--accent-dark: var(--blue);
 	--gray: var(--gray-light-theme);
 


### PR DESCRIPTION
This is a minimal change that replaces the yellow/brown accents with the far more fetching green colour selected from the colour wheel introduced by #2. This is shown in the following screenshots of the home page in both light and dark themes. 

Light theme:
![image](https://github.com/user-attachments/assets/1a1440fc-b75b-45f7-a70a-2ff4e6484f2d)

Dark theme:
![image](https://github.com/user-attachments/assets/66a3c5de-671f-444c-b5d9-9c1e921d2400)

The impetus for implementing such a change is to improve the look and feel of the website. There is little change to the overall readibility or accessibility in my opinion.

