### PR TITLE
Redesign author block

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -100,15 +100,10 @@ const { title, description, pubDate, updatedDate, heroImage, authors } = Astro.p
 							}
 						</div>
 						<h1>{title}</h1>
-
-						<p class="by">{authors.length > 1 ? "authors:" : "author:"}</p>
-						<ul class="author-names">
-						{authors.map((name : string) => (
-								<li>{name}</li>		
-							))
-						}</ul>
-
-						<hr />
+						<h6 class="by">
+							{authors.length > 1 ? "Authors:" : "Author:"}
+							{authors.join(", ")}
+						</h6>
 					</div>
 					<slot />
 				</div>
@@ -122,18 +117,10 @@ const { title, description, pubDate, updatedDate, heroImage, authors } = Astro.p
 
 
 .by {
-	text-align: left;
+	text-align: center;
+	margin-top: -0.8em;
 	margin-bottom: 0.5em;
 	padding-bottom: 0px;
-}
-
-
-.author-names {
-	text-align: left;
-
-}
-
-.author-names li{
 	color: var(--text-color);
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -135,6 +135,7 @@ h5 {
 	color: hsl(from var(--accent) h s calc(l * 0.6));
 }
 h6 {
+	font-size: 1.00em;
 	color: hsl(from var(--accent) h s calc(l * 0.5));
 }
 


### PR DESCRIPTION
This is a minimal change to improve the consistency of the author block in the BlogPost layout. Authors are moved from a bullet pointed list to a heading consistent with the date and title blocks with an ommitted full-stop. Commas are placed inbetween authors for clarity.

Before:
![image](https://github.com/user-attachments/assets/98b2b91f-346f-4144-b4f7-5a85f32e085c)

After:
![image](https://github.com/user-attachments/assets/7d7d7c34-8db2-47c4-87c6-b090a2ff8e37)

For a single author article no commas are added. See for example:
![image](https://github.com/user-attachments/assets/0d1a9371-e46f-46a7-88aa-4b3e62fefadb)
