### PR TITLE
1 post tagging

### DIFF
--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -13,7 +13,7 @@ import FormattedDate from './FormattedDate.astro';
 // Configs fuse.js
 // https://fusejs.io/api/options.html
 const options = {
-	keys: ['data.title', 'data.description', 'slug'],
+	keys: ['data.title', 'data.description', 'data.tags', 'slug'],
 	includeMatches: true,
 	minMatchCharLength: 2,
 	threshold: 0.5,

--- a/src/content/blog/markdown-style-guide.md
+++ b/src/content/blog/markdown-style-guide.md
@@ -4,6 +4,8 @@ description: 'Here is a sample of some basic Markdown syntax that can be used wh
 pubDate: 'Jun 19 2024'
 updatedDate: 'Mar 13 2024'
 heroImage: '/blog-placeholder-1.jpg'
+tags: 
+- markdown
 authors: 
 - astro
 - sirlilpanda

--- a/src/content/blog/second-post.md
+++ b/src/content/blog/second-post.md
@@ -3,6 +3,9 @@ title: 'Second post'
 description: 'Lorem ipsum dolor sit amet'
 pubDate: 'Jul 15 2022'
 heroImage: '/blog-placeholder-4.jpg'
+tags:
+- frogs
+- toads
 authors:
 - astro
 ---

--- a/src/content/blog/third-post.md
+++ b/src/content/blog/third-post.md
@@ -3,6 +3,9 @@ title: 'Third post'
 description: 'Lorem ipsum dolor sit amet'
 pubDate: 'Jul 22 2022'
 heroImage: '/blog-placeholder-2.jpg'
+tags:
+- frogs
+- newts
 authors:
 - astro
 ---

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -6,7 +6,7 @@ const blog = defineCollection({
 	schema: z.object({
 		title: z.string(),
 		authors : z.array(z.string()),
-		tags : z.array(z.string().optional()).optional(),
+		tags : z.array(z.string()).optional(),
 		description: z.string(),
 		// Transform string to Date object
 		pubDate: z.coerce.date(),


### PR DESCRIPTION
Posts can now be tagged and searched for appropriately.

Third post now as the tags:
- frogs
- newts
as seen below 
![image](https://github.com/user-attachments/assets/90cd45dc-455e-4f51-9da6-b35625d4a7c5)

second post now has the tags:
- frogs
- toads
as can be seen below
![image](https://github.com/user-attachments/assets/4e80f9e5-4f40-4205-81b3-dac60a0fa1b7)

as can be seen searching for frogs will bring up both the second and third post
![image](https://github.com/user-attachments/assets/c57b3060-3ed8-4c55-898a-081c176b433a)


where only searching for only toads will only bring up the second post.
![image](https://github.com/user-attachments/assets/b1c8dfe9-c477-4c57-9930-85db89d707fa)


Currently the only limitation with this solutions is only one tag can be search for at a time.


